### PR TITLE
fix: Change the value of choices depending on the settings of formats.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -121,3 +121,4 @@ The following is a list of much appreciated contributors:
 * striveforbest (Alex Zagoro)
 * josx (José Luis Di Biase)
 * Jan Rydzewski
+* shimakaze-git

--- a/import_export/admin.py
+++ b/import_export/admin.py
@@ -473,9 +473,11 @@ class ExportActionMixin(ExportMixin):
         choices = []
         formats = self.get_export_formats()
         if formats:
-            choices.append(('', '---'))
             for i, f in enumerate(formats):
                 choices.append((str(i), f().get_title()))
+
+        if len(formats) > 1:
+            choices.insert(0, ('', '---'))
 
         self.action_form = export_action_form_factory(choices)
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
**Problem**

What problem have you solved?
どのような問題を解決しましたか？

このissueのPRです。
以下のコードのように`formats`が一つしかない場合、Exportアクション上のformatから`---`を表示させないようにしました。
デフォルトでformatsで指定した内容が選べるようになります。

```python
from import_export.admin import ExportActionModelAdmin
from import_export.formats import base_formats

class CategoryAdmin(ExportActionModelAdmin):

    formats = [base_formats.CSV]
```

**Solution**

How did you solve the problem?

どのようにして問題を解決しましたか？

`import_export/admin.py`の`ExportActionMixin`のコンストラクタ内で、`formats`のサイズが1を超える場合は`---`をchoicesに加えるようにしました。

**Acceptance Criteria**

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 

テストを書いたことがありますか？該当する場合、変更のスクリーンショットを含めましたか？
変更を文書化しましたか？

`tests/core/admin.py`にある`CategoryAdmin`を以下のように修正した後に、管理画面の中にあるExportアクションのformatがcsvになっていることを確認しました。

```python
class CategoryAdmin(ExportActionModelAdmin):

    formats = [base_formats.CSV]
```